### PR TITLE
BZC-75-create-delete-api-cart_items-id

### DIFF
--- a/backend/router_api_shop.go
+++ b/backend/router_api_shop.go
@@ -11,7 +11,8 @@ func (cfg *apiConfig) registerApiShopRoutes(mux *http.ServeMux) {
 	mux.Handle("GET /api/products", http.HandlerFunc(cfg.handleApiGetProducts))
 	mux.Handle("GET /api/categories", http.HandlerFunc(cfg.handleApiGetCategories))
 	mux.Handle("GET /api/categories/{slug}/products", http.HandlerFunc(cfg.handleApiGetCategoryProducts))
-	mux.Handle("POST /api/carts/add", cfg.optionalAuth(http.HandlerFunc(cfg.handleApiAddToCart)))
+	mux.Handle("POST /api/carts/variants", cfg.optionalAuth(http.HandlerFunc(cfg.handleApiAddToCart)))
 	mux.Handle("GET /api/carts", cfg.optionalAuth(http.HandlerFunc(cfg.handleApiGetCart)))
+	mux.Handle("DELETE /api/carts/variants/{id}", cfg.optionalAuth(http.HandlerFunc(cfg.handleApiDeleteFromCart)))
 	log.Printf("Shop API routes registered")
 }


### PR DESCRIPTION
BZC-75 added /api/carts/variants DELETE endpoint, renamed the /api/carts/add endpoint to /api/carts/variants for consistency
